### PR TITLE
Updating assessment breakdown for null trainee

### DIFF
--- a/client-side/src/app/Caliber/reports/assessment-breakdown/assessment-breakdown.component.ts
+++ b/client-side/src/app/Caliber/reports/assessment-breakdown/assessment-breakdown.component.ts
@@ -77,8 +77,6 @@ export class AssessmentBreakdownComponent implements OnInit, OnDestroy {
                 this.labels = incomingLabels;
             }
           }
-        } else {
-          console.log('Failed to load assessment data');
         }
       });
 
@@ -94,14 +92,21 @@ export class AssessmentBreakdownComponent implements OnInit, OnDestroy {
 
   tryFetch() {
     // Check that all objects are present
-    if (this.batchId && this.week !== null && this.traineeId) {
+    if (this.batchId && this.week !== null && this.traineeId !== undefined) {
       if (this.week === 0) {
         // If week is 0, fetch data for all weeks
+        console.log('Fetching @ week === 0');
         this.reportsService.fetchBatchOverallTraineeBarChart(this.batchId, this.traineeId);
-      } else {
+      } else if (this.traineeId > 0) {
+        console.log('fetching @ traineeId > 0');
         // Else fetch data for the specific week
         this.reportsService.fetchBatchWeekTraineeBarChart(this.batchId, this.week, this.traineeId);
+      } else {
+        console.log('fetching @ else');
+        this.reportsService.fetchBatchWeekAvgBarChart(this.batchId, this.week);
       }
+    } else {
+      console.log( this.batchId + ', ' + this.week + ', ' + this.traineeId);
     }
   }
 

--- a/client-side/src/app/Caliber/reports/assessment-breakdown/assessment-breakdown.component.ts
+++ b/client-side/src/app/Caliber/reports/assessment-breakdown/assessment-breakdown.component.ts
@@ -95,18 +95,13 @@ export class AssessmentBreakdownComponent implements OnInit, OnDestroy {
     if (this.batchId && this.week !== null && this.traineeId !== undefined) {
       if (this.week === 0) {
         // If week is 0, fetch data for all weeks
-        console.log('Fetching @ week === 0');
         this.reportsService.fetchBatchOverallTraineeBarChart(this.batchId, this.traineeId);
       } else if (this.traineeId > 0) {
-        console.log('fetching @ traineeId > 0');
         // Else fetch data for the specific week
         this.reportsService.fetchBatchWeekTraineeBarChart(this.batchId, this.week, this.traineeId);
       } else {
-        console.log('fetching @ else');
         this.reportsService.fetchBatchWeekAvgBarChart(this.batchId, this.week);
       }
-    } else {
-      console.log( this.batchId + ', ' + this.week + ', ' + this.traineeId);
     }
   }
 

--- a/client-side/src/app/Caliber/reports/reports.component.html
+++ b/client-side/src/app/Caliber/reports/reports.component.html
@@ -2,13 +2,13 @@
 <div class="container">
     <div class="row reports-row">
         <div class="col-md-12">
-            <app-weekly-line-chart *ngIf="traineeId === null"></app-weekly-line-chart>
+            <app-weekly-line-chart *ngIf="traineeId === 0"></app-weekly-line-chart>
             <app-assessment-breakdown></app-assessment-breakdown>
         </div>
     </div>
     <div class="row reports-row"> 
         <div class="col-md-4">
-            <app-trainee-tech-skills></app-trainee-tech-skills>
+            <app-trainee-tech-skills *ngIf="traineeId === 0"></app-trainee-tech-skills>
         </div>
         <div class="col-md-8">
             <app-batch-overall-line-chart></app-batch-overall-line-chart>

--- a/client-side/src/app/Caliber/reports/services/granularity.service.ts
+++ b/client-side/src/app/Caliber/reports/services/granularity.service.ts
@@ -161,9 +161,10 @@ export class GranularityService {
 
     this.currentBatch.next(testBatch);
 
-    // const testTrainee: Trainee = null;
+    // Default testing trainee Id: 5530
+
     const testTrainee: Trainee = {
-      'traineeId': 5530, 'resourceId': null, 'name': 'Ali, Fareed', 'email': 'fareed.ali37@qmail.cuny.edu',
+      'traineeId': 0, 'resourceId': null, 'name': 'Ali, Fareed', 'email': 'fareed.ali37@qmail.cuny.edu',
       'trainingStatus': 'Employed', 'phoneNumber': '347-526-5184', 'skypeId': 'live:bassph',
       'profileUrl': 'https://app.revature.com/profile/fareed/03198a1e81a3f4e32433a9e9c9db353e',
       'recruiterName': null, 'college': null, 'degree': null, 'major': null, 'techScreenerName': null,
@@ -171,7 +172,7 @@ export class GranularityService {
     };
     this.currentTrainee.next(testTrainee);
 
-    const week = 0;
+    const week = 4;
     this.currentWeek.next(week);
   }
 

--- a/client-side/src/app/services/reporting.service.ts
+++ b/client-side/src/app/services/reporting.service.ts
@@ -119,17 +119,21 @@ export class ReportingService {
 
   fetchAllBatchesCurrentWeekQCStackedBarChart(batchId: Number, week: Number) {
     const endpoint = environment.apiAllBatchesCurrentWeekQCStackedBarChart(batchId, week);
-
     // TODO: Implement API call and subject push logic
-
   }
 
   /* Bar Charts */
   fetchBatchWeekAvgBarChart(batchId: Number, week: Number) {
     const endpoint = environment.apiBatchWeekAvgBarChart(batchId, week);
+    const params = {
+      batchId: batchId,
+      week: week
+    };
 
-    // TODO: Implement API call and subject push logic
-
+    if (this.needsRefresh(this.assessmentBreakdownBarChart, params)) {
+      this.httpClient.get(endpoint).subscribe(
+        success => this.assessmentBreakdownBarChart.next({ params: params, data: success}));
+    }
   }
 
   fetchBatchWeekSortedBarChart(batchId: Number, week: Number) {

--- a/client-side/src/environments/environment.ts
+++ b/client-side/src/environments/environment.ts
@@ -47,7 +47,7 @@ export const environment = {
     environment.context + `all/reports/batch/{batchId}/chart`,
 
   apiAllBatchesCurrentWeekQCStackedBarChart: (batchId: Number, week: Number) =>
-    environment.context + `all/reports/batch/${batchId}/week/${week}/bar-batch-week-avg`,
+    environment.context + `all/reports/batch/week/stacked-bar-current-week`,
 
   apiBatchWeekAvgBarChart: (batchId: Number, week: Number) =>
     environment.context + `all/reports/batch/${batchId}/week/${week}/bar-batch-week-avg`,


### PR DESCRIPTION
Note: Branch name is a misnomer. We decided to instead use a Trainee object with an id of 0 to designate no specific trainee was selected rather than a null trainee object.