### PR TITLE
Reports tables cleanup.

### DIFF
--- a/client-side/src/app/Caliber/caliber.module.ts
+++ b/client-side/src/app/Caliber/caliber.module.ts
@@ -94,7 +94,6 @@ import { WeeklyFeedbackComponent } from './reports/weekly-feedback/weekly-feedba
 import { WeeklyGradesComponent } from './reports/weekly-grades/weekly-grades.component';
 import { WeeklyAuditComponent } from './reports/weekly-audit/weekly-audit.component';
 import { CumulativeScoreComponent } from './reports/cumulative-scores/cumulative-scores.component';
-import { DoughnutComponent } from './doughnut/doughnut.component';
 import { AlertsComponent } from './alerts/alerts.component';
 import { ReactivateLocationComponent } from './settings/locations/reactivatelocation/reactivatelocation.component';
 import { BarGraphModalComponent } from './home/vp-bar-graph/bar-graph-modal/bargraphmodal.component';
@@ -158,7 +157,6 @@ import { QcDoughnutComponent } from './reports/qc-doughnut/qc-doughnut.component
     PanelFeedbackComponent,
     WeeklyAuditComponent,
     CumulativeScoreComponent,
-    DoughnutComponent,
     ReactivateLocationComponent,
     AlertsComponent,
     BarGraphModalComponent,

--- a/client-side/src/app/Caliber/reports/overall-feedback/overall-feedback.component.html
+++ b/client-side/src/app/Caliber/reports/overall-feedback/overall-feedback.component.html
@@ -2,7 +2,7 @@
   <div class="container">
     <header class="feedback-heading">Overall Feedback</header>
     <div class="table-responsive">
-      <table class="table table-responsive">
+      <table class="table">
         <thead>
           <tr>
             <td>Week</td>
@@ -15,12 +15,15 @@
           <tr>
             <td>{{week+1}}</td>
             <td>{{topic}}</td>
-            <td *ngIf="qcNotes">{{qcWeek(week+1).qcStatus}}</td>
-            <td *ngIf="qcNotes">{{qcWeek(week+1).content}}</td>
+            <td *ngIf="!qcWeek(week+1)" colspan="2"><em>No QC notes were found for this trainee.</em></td>
+            <td *ngIf="qcWeek(week+1) && qcWeek(week+1).qcStatus">{{qcWeek(week+1).qcStatus}}</td>
+            <td *ngIf="qcWeek(week+1) && !qcWeek(week+1).qcStatus">-</td>
+            <td *ngIf="qcWeek(week+1) && qcWeek(week+1).content">{{qcWeek(week+1).content}}</td>
+            <td *ngIf="qcWeek(week+1) && !qcWeek(week+1).content">-</td>
           </tr>
           <tr>
             <th>Notes:</th>
-            <td class="align-left" colspan="3" *ngIf="allNotes">
+            <td class="align-left" colspan="3" *ngIf="allNotes && allNotes.length > 0">
               {{allWeek(week+1).content}}
             </td>
           </tr>
@@ -29,3 +32,4 @@
     </div>
   </div>
 </div>
+  

--- a/client-side/src/app/Caliber/reports/panel-batch-all-trainees/panel-batch-all-trainees.component.html
+++ b/client-side/src/app/Caliber/reports/panel-batch-all-trainees/panel-batch-all-trainees.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <header class="panel-heading">Panel Feedback</header>
   <div class="table-responsive">
-    <table class="table table-responsive">
+    <table class="table">
       <thead>
         <tr>
           <td class="trainee-name">Trainee</td>

--- a/client-side/src/app/Caliber/reports/panel-feedback/panel-feedback.component.html
+++ b/client-side/src/app/Caliber/reports/panel-feedback/panel-feedback.component.html
@@ -53,7 +53,7 @@
         </header>
 
         <div class="table-responsive">
-          <table class="table table-sm table-responsive">
+          <table class="table table-sm">
             <thead>
               <tr class="table-default">
                 <th class="left">Technology</th>
@@ -80,47 +80,47 @@
 
       <!-- Start Overall Feedback Container -->
       <div class="container">
-          <header class="feedback-heading">
-            Overall Feedback
-          </header>
-          <div class="table-responsive">
-            <table class="table table-sm table-responsive">
-              <thead>
-                <tr class="table-default">
-                  <th class="left">Criteria</th>
-                  <th>Comment</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td class="overall-feedback-title">Associate Introduction</td>
-                  <td>{{panel.associateIntro}}</td>
-                </tr>
-                <tr>
-                  <td class="overall-feedback-title">Project 1 Explanation</td>
-                  <td>{{panel.projectOneDescription}}</td>
-                </tr>
-                <tr>
-                  <td class="overall-feedback-title">Project 2 Explanation</td>
-                  <td>{{panel.projectTwoDescription}}</td>
-                </tr>
-                <tr>
-                  <td class="overall-feedback-title">Project 3 Explanation</td>
-                  <td>{{panel.projectThreeDescription}}</td>
-                </tr>
-                <tr>
-                  <td class="overall-feedback-title">Communication Skills</td>
-                  <td>{{panel.communicationSkills}}</td>
-                </tr>
-                <tr>
-                  <td class="overall-feedback-title">Overall</td>
-                  <td>{{panel.overall}}</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+        <header class="feedback-heading">
+          Overall Feedback
+        </header>
+        <div class="table-responsive">
+          <table class="table table-sm">
+            <thead>
+              <tr class="table-default">
+                <th class="left">Criteria</th>
+                <th>Comment</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="overall-feedback-title">Associate Introduction</td>
+                <td>{{panel.associateIntro}}</td>
+              </tr>
+              <tr>
+                <td class="overall-feedback-title">Project 1 Explanation</td>
+                <td>{{panel.projectOneDescription}}</td>
+              </tr>
+              <tr>
+                <td class="overall-feedback-title">Project 2 Explanation</td>
+                <td>{{panel.projectTwoDescription}}</td>
+              </tr>
+              <tr>
+                <td class="overall-feedback-title">Project 3 Explanation</td>
+                <td>{{panel.projectThreeDescription}}</td>
+              </tr>
+              <tr>
+                <td class="overall-feedback-title">Communication Skills</td>
+                <td>{{panel.communicationSkills}}</td>
+              </tr>
+              <tr>
+                <td class="overall-feedback-title">Overall</td>
+                <td>{{panel.overall}}</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
-        <!-- End Overall Feedback Container -->
+      </div>
+      <!-- End Overall Feedback Container -->
         
     </div>
   </div>

--- a/client-side/src/app/Caliber/reports/weekly-audit/weekly-audit.component.html
+++ b/client-side/src/app/Caliber/reports/weekly-audit/weekly-audit.component.html
@@ -8,30 +8,32 @@
         <strong>Categories covered this week: </strong>
         <span *ngIf="weekTopics">{{weekTopics}}</span>
       </div>
-      <table class="table table-responsive">
-        <thead>
-          <tr>
-            <td>Trainee</td>
-            <td>Individual Feedback</td>
-            <td>Notes</td>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let note of (traineeNotes | orderBy:'trainee.name')" class="feedback-trainee">
-            <td>{{note.trainee.name}}</td>
-            <td>{{note.qcStatus}}</td>
-            <td>{{note.content}}</td>
-          </tr>
-          <tr>
-            <th>Overall Feedback:</th>
-            <td colspan="2">{{batchNote.qcStatus}}</td>
-          </tr>
-          <tr>
-            <th>Notes:</th>
-            <td colspan="2">{{batchNote.content}}</td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="table-responsive">
+        <table class="table">
+          <thead>
+            <tr>
+              <td>Trainee</td>
+              <td>Individual Feedback</td>
+              <td>Notes</td>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let note of (traineeNotes | orderBy:'trainee.name')" class="feedback-trainee">
+              <td>{{note.trainee.name}}</td>
+              <td>{{note.qcStatus}}</td>
+              <td>{{note.content}}</td>
+            </tr>
+            <tr>
+              <th>Overall Feedback:</th>
+              <td colspan="2">{{batchNote.qcStatus}}</td>
+            </tr>
+            <tr>
+              <th>Notes:</th>
+              <td colspan="2">{{batchNote.content}}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </div>  

--- a/client-side/src/app/Caliber/reports/weekly-feedback/weekly-feedback.component.html
+++ b/client-side/src/app/Caliber/reports/weekly-feedback/weekly-feedback.component.html
@@ -8,22 +8,24 @@
         <strong>Categories covered this week: </strong>
         <span *ngIf="weekTopics">{{weekTopics}}</span>
       </div>
-      <table class="table table-responsive">
-        <thead>
-          <tr>
-            <td>Trainer Feedback</td>
-            <td>Quality Audit</td>
-            <td>QC Feedback</td>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td *ngIf="trainerNote">{{trainerNote.content}}</td>
-            <td *ngIf="qcNote">{{qcNote.qcStatus}}</td>
-            <td *ngIf="qcNote">{{qcNote.content}}</td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="table-responsive">
+        <table class="table">
+          <thead>
+            <tr>
+              <td>Trainer Feedback</td>
+              <td>Quality Audit</td>
+              <td>QC Feedback</td>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td *ngIf="trainerNote">{{trainerNote.content}}</td>
+              <td *ngIf="qcNote">{{qcNote.qcStatus}}</td>
+              <td *ngIf="qcNote">{{qcNote.content}}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 </div>

--- a/client-side/src/app/Caliber/reports/weekly-grades/weekly-grades.component.html
+++ b/client-side/src/app/Caliber/reports/weekly-grades/weekly-grades.component.html
@@ -8,33 +8,34 @@
         <strong>Categories covered this week: </strong>
         <span *ngIf="weekTopics">{{weekTopics}}</span>
       </div>
-      <table class="table table-responsive table-sm">
-        <thead>
-          <tr>
-            <td>Trainee</td>
-            <td *ngFor="let assess of assessments">
-              {{assess.title}} ({{assess.rawScore}}%)
-            </td>
-            <td>Overall</td>
-          </tr>
-        </thead>
-        <tbody *ngFor="let trainee of (batch.trainees | orderBy:'name')">
-          <tr *ngIf="grades && assessments">
-            <th rowspan="2">{{trainee.name}}</th>
-            <td *ngFor="let grade of (grades | filterBy:'trainee.traineeId':trainee.traineeId)">
-              {{grade.score | number:'2.2-2'}}%
-            </td>
-            <th>
-              {{overallScore(trainee.traineeId) | number:'2.2-2'}}%
-            </th>
-          </tr>
-          <tr *ngIf="traineeNotes && traineeNotes.length > 0">
-            <td *ngIf="assessments" [colSpan]="assessments.length + 1">
-              <strong>Notes: </strong>{{noteContent(trainee.traineeId)}}
-            </td>
-          </tr>
-        </tbody>
-        <tbody>
+      <div class="table-responsive">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <td>Trainee</td>
+              <td *ngFor="let assess of assessments">
+                {{assess.title}} ({{assess.rawScore}}%)
+              </td>
+              <td>Overall</td>
+            </tr>
+          </thead>
+          <tbody *ngFor="let trainee of (batch.trainees | orderBy:'name')">
+            <tr *ngIf="grades && assessments">
+              <th rowspan="2">{{trainee.name}}</th>
+              <td *ngFor="let grade of (grades | filterBy:'trainee.traineeId':trainee.traineeId)">
+                {{grade.score | number:'2.2-2'}}%
+              </td>
+              <th>
+                {{overallScore(trainee.traineeId) | number:'2.2-2'}}%
+              </th>
+            </tr>
+            <tr *ngIf="traineeNotes && traineeNotes.length > 0">
+              <td *ngIf="assessments" [colSpan]="assessments.length + 1">
+                <strong>Notes: </strong>{{noteContent(trainee.traineeId)}}
+              </td>
+            </tr>
+          </tbody>
+          <tbody>
             <tr>
               <th>Average</th>
               <td *ngFor="let assess of assessments">
@@ -45,7 +46,8 @@
               </th>
             </tr>
           </tbody>
-      </table>
+        </table>
+      </div>
       <div class="feedback-sub">
         <div><strong>Notes: </strong></div>
         <div *ngIf="batchNote">{{batchNote.content}}</div>


### PR DESCRIPTION
The changes to the package.json made a few days back caused some issues with the tables not tied to any specific charts in the reports section. The table-responsive class wasn't being properly applied to any of those components.
Additionally, there was an issue with the caliber module where it was still including the previously deleted DoughnutComponent.

This set of changes resolves these issues.